### PR TITLE
fix: load existing indexes with correct suffix.

### DIFF
--- a/src/system/catalog.cc
+++ b/src/system/catalog.cc
@@ -74,7 +74,7 @@ Catalog::Catalog(const string& filename) {
     switch (index_type) {
     case IndexType::B_PLUS_TREE: {
       auto key_col_idx = read_int64();
-      index = std::make_unique<BPlusTree>(*heap_file.get(), key_col_idx, normalize(table_name));
+      index = std::make_unique<BPlusTree>(*heap_file.get(), key_col_idx, normalize(table_name) + ".bpt");
       break;
     }
     case IndexType::NONE:


### PR DESCRIPTION
This PR fixes an index loading error. If a table with an existing index is loaded (as in not created during the binary execution) then the prefix ".bpt" is not added to its file identifier resulting in the creation of new index files with the form `{table_name}.leaf` and `{table_name}.dir`.